### PR TITLE
xref fixes for vrc build 1156

### DIFF
--- a/UserInfoExtensions/Modules/QuickMenuFromSocial.cs
+++ b/UserInfoExtensions/Modules/QuickMenuFromSocial.cs
@@ -35,6 +35,7 @@ namespace UserInfoExtensions.Modules
                     UiManager.CloseBigMenu();
                     UiManager.OpenQuickMenu();
 
+                    UiManager.OpenQuickMenuPage("QuickMenuHere");
                     UiManager.OpenUserInQuickMenu(player.field_Private_APIUser_0);
 
                     return;

--- a/VRChatUtilityKit/Ui/UiManager.cs
+++ b/VRChatUtilityKit/Ui/UiManager.cs
@@ -90,7 +90,7 @@ namespace VRChatUtilityKit.Ui
         internal static MethodInfo _pushPageMethod;
         internal static MethodInfo _removePageMethod;
 
-        //private static MethodInfo _openQuickMenuPageMethod;
+        private static MethodInfo _openQuickMenuPageMethod;
         private static MethodInfo _openQuickMenuMethod;
 
         private static MethodInfo _closeMenuMethod;
@@ -143,15 +143,15 @@ namespace VRChatUtilityKit.Ui
             _openQuickMenuMethod = typeof(UIManagerImpl).GetMethods()
                 .First(method => method.Name.StartsWith("Method_Public_Void_Boolean_") && method.Name.Length <= 29 && XrefUtils.CheckUsing(method, "Method_Private_Void_") && !XrefUtils.CheckUsing(method, "SetActive"));
 
-            /*_openQuickMenuPageMethod = typeof(UIManagerImpl).GetMethods()
+            _openQuickMenuPageMethod = typeof(UIManagerImpl).GetMethods()
                 .First(method => method.Name.StartsWith("Method_Public_Virtual_Final_New_Void_String_") && XrefUtils.CheckUsing(method, _openQuickMenuMethod.Name, _openQuickMenuMethod.DeclaringType));
-            MelonLogger.Msg("2");
+
             // Patching the other method doesn't work for some reason you have to patch this
             MethodInfo _onQuickMenuOpenedMethod = typeof(UIManagerImpl).GetMethods()
-                .First(method => method.Name.StartsWith("Method_Private_Void_Boolean_") && !method.Name.Contains("_PDM_") && XrefUtils.CheckUsedBy(method, _openQuickMenuMethod.Name));*/
+                .First(method => method.Name.StartsWith("Method_Private_Void_Boolean_") && !method.Name.Contains("_PDM_") && XrefUtils.CheckUsedBy(method, _openQuickMenuMethod.Name));
 
-            MethodInfo _onQuickMenuOpenedMethod = typeof(UIManagerImpl).GetMethods()
-                .First(method => method.Name.StartsWith("Method_Private_Void_Boolean_") && !method.Name.Contains("_PDM_"));
+           /* MethodInfo _onQuickMenuOpenedMethod = typeof(UIManagerImpl).GetMethods()
+                .First(method => method.Name.StartsWith("Method_Private_Void_Boolean_") && !method.Name.Contains("_PDM_"));*/
             VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(_onQuickMenuOpenedMethod, null, new HarmonyMethod(typeof(UiManager).GetMethod(nameof(OnQuickMenuOpen), BindingFlags.NonPublic | BindingFlags.Static)));
 
             _popupV2Small = typeof(VRCUiPopupManager).GetMethods()
@@ -289,6 +289,11 @@ namespace VRChatUtilityKit.Ui
         /// Opens the QuickMenu.
         /// </summary>
         public static void OpenQuickMenu() => _openQuickMenuMethod?.Invoke(UIManagerImpl.prop_UIManagerImpl_0, new object[1] { true });
+
+        /// <summary>
+        /// Opens the specified QuickMenu page.
+        /// </summary>
+        public static void OpenQuickMenuPage(string quickMenuPage) => _openQuickMenuPageMethod?.Invoke(UIManagerImpl.prop_UIManagerImpl_0, new object[1] { quickMenuPage });
 
         /// <summary>
         /// Closes the QuickMenu.

--- a/VRChatUtilityKit/Ui/UiManager.cs
+++ b/VRChatUtilityKit/Ui/UiManager.cs
@@ -141,7 +141,7 @@ namespace VRChatUtilityKit.Ui
             VRChatUtilityKitMod.Instance.HarmonyInstance.Patch(_closeQuickMenuMethod, null, new HarmonyMethod(typeof(UiManager).GetMethod(nameof(OnQuickMenuClose), BindingFlags.NonPublic | BindingFlags.Static)));
 
             _openQuickMenuMethod = typeof(UIManagerImpl).GetMethods()
-                .First(method => method.Name.StartsWith("Method_Public_Void_Boolean_") && method.Name.Length <= 29 && XrefUtils.CheckUsing(method, "Method_Private_Void_"));
+                .First(method => method.Name.StartsWith("Method_Public_Void_Boolean_") && method.Name.Length <= 29 && XrefUtils.CheckUsing(method, "Method_Private_Void_") && !XrefUtils.CheckUsing(method, "SetActive"));
 
             /*_openQuickMenuPageMethod = typeof(UIManagerImpl).GetMethods()
                 .First(method => method.Name.StartsWith("Method_Public_Virtual_Final_New_Void_String_") && XrefUtils.CheckUsing(method, _openQuickMenuMethod.Name, _openQuickMenuMethod.DeclaringType));
@@ -171,7 +171,8 @@ namespace VRChatUtilityKit.Ui
             _selectedUserManagerObject = GameObject.Find("_Application/UIManager/SelectedUserManager").GetComponent<UserSelectionManager>();
 
             _selectUserMethod = typeof(UserSelectionManager).GetMethods()
-                .First(method => method.Name.StartsWith("Method_Public_Void_APIUser_") && !method.Name.Contains("_PDM_") && XrefUtils.CheckUsedBy(method, "Method_Public_Virtual_Final_New_Void_IUser_"));
+                .First(method => method.Name.StartsWith("Method_Public_Void_APIUser_") && !method.Name.Contains("_PDM_")
+                && XrefUtils.CheckUsedByCount(method, "Method_Public_Virtual_Final_New_Void_IUser_") >= 3);
 
             MethodInfo[] pageMethods = typeof(UIPage).GetMethods()
                 .Where(method => method.Name.StartsWith("Method_Public_Void_UIPage_") && !method.Name.Contains("_PDM_"))

--- a/VRChatUtilityKit/Utilities/XrefUtils.cs
+++ b/VRChatUtilityKit/Utilities/XrefUtils.cs
@@ -116,6 +116,34 @@ namespace VRChatUtilityKit.Utilities
             => CheckUsing(method, usingMethod => usingMethod != null && (type == null || usingMethod.DeclaringType == type) && usingMethod.Name.Contains(methodName));
 
         /// <summary>
+        /// Counts how many times the given method is used by.
+        /// Note: the methods passed into the predicate may be false.
+        /// </summary>
+        /// <param name="method">The method to check</param>
+        /// <param name="predicate">The predicate to check the methods against</param>
+        /// <returns>the number of times the given method is called by a method with the given name of the given type</returns>
+        public static int CheckUsedByCount(MethodBase method, Func<MethodBase, bool> predicate)
+        {
+            int methodCount = 0;
+            foreach (XrefInstance instance in XrefScanner.UsedBy(method))
+            {
+                if (instance.Type == XrefType.Method && predicate.Invoke(instance.TryResolve()))
+                    methodCount++;
+            }
+            return methodCount;
+        }
+
+        /// <summary>
+        /// Returns the number of times the given method is called by the other given method.
+        /// </summary>
+        /// <param name="method">The method to check</param>
+        /// <param name="methodName">The name of the method that uses the given method</param>
+        /// <param name="type">The type of the method that uses the given method</param>
+        /// <returns>the number of times the given method is called by a method with the given name of the given type</returns>
+        public static int CheckUsedByCount(MethodBase method, string methodName, Type type = null)
+            => CheckUsedByCount(method, usedByMethod => usedByMethod != null && (type == null || usedByMethod.DeclaringType == type) && usedByMethod.Name.Contains(methodName));
+
+        /// <summary>
         /// Dumps the Xref information on a method.
         /// This is for DEBUG PURPOSES ONLY.
         /// </summary>


### PR DESCRIPTION
this PR fixes xref scanning for `_openQuickMenuMethod` and `_selectUserMethod`, adds an `OpenQuickMenuPage` method (takes a string with page name as parameter) and implements it into UserInfoExtensions to switch to the `Here` page (`QuickMenuHere`) when opening a user on the quick menu